### PR TITLE
varianttable.py: correct INFO and FORMAT field rendering for single Float or Integer entries

### DIFF
--- a/igv_reports/varianttable.py
+++ b/igv_reports/varianttable.py
@@ -81,9 +81,9 @@ def render_value(v):
 
 
 def render_values(v):
-    if not isinstance(v, str):
-        return ','.join(map(render_value, v))
-    return v
+    if isinstance(v, str) or isinstance(v, int) or isinstance(v, float):
+        return render_value(v)
+    return ','.join(map(render_value, v))
 
 
 def render_id(v):


### PR DESCRIPTION
varianttable.py: ensure that INFO and FORMAT fields with a single (Header spec `Number=1`) entry are properly rendered when they are float (Header spec `Type=Float`) or integer (Header spec `Type=Integer`)