### PR TITLE
Bugfix decoding annotation field

### DIFF
--- a/igv_reports/varianttable.py
+++ b/igv_reports/varianttable.py
@@ -99,7 +99,9 @@ def render_ids(v):
 
 def decode_ann(variant):
     """Decode the standardized ANN field to something human readable."""
-    annotations = [e.split("|") for e in variant.info["ANN"]]
+    annotations = ([variant.info['ANN'].split('|'
+                   )] if isinstance(variant.info['ANN'],
+                   str) else [e.split('|') for e in variant.info['ANN']])
     effects = []
     for allele in variant.alts:
         for ann in annotations:


### PR DESCRIPTION
When decoding the annotation field igv-reports may crash as it is possible that `variant.info["ANN"]` just returns a string instead of a list.
This is now solved by first checking if a string is returned and treating the result accordingly.