### PR TITLE
bugfix: standalone js-parsing

### DIFF
--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -118,8 +118,8 @@ def create_report(args):
 
             for i, line in enumerate(data):
 
-                if standalone and line.find("<script") and line.find(".js") > 0:
-                    print(inline_script(line, o))
+                if standalone and "<script" in line and line.find(".js") > 0:
+                    inline_script(line, o)
 
                 else:
                     j = line.find('"@TABLE_JSON@"')


### PR DESCRIPTION
This PR contains a bugfix where some lines in the html-template were recognized as JS-Files.
This happens as `line.find("<script")` returns `-1` if the string is not found in the current line.
So, this part of the if-closure always returns true and every line holding the substring ".js" is parsed as JS-File if the standalone-parameter is set.