### PR TITLE
css inline parsing and removal of linkouts

### DIFF
--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -141,26 +141,26 @@ def inline_script(line, o, source_type):
     if source_type == "js":
         s = line.find('src="')
         offset = 5
+        o.write('<script type="text/javascript">\n')
     elif source_type == "css":
         s = line.find('href="')
         offset = 6
+        o.write('<style type="text/css">\n')
+    else:
+        raise KeyError("Inline script must be either js- or css-file")
     if s > 0:
         e = line.find('">', s)
         url = line[s+offset:e]
         response = urlopen(url)
         content = response.read().decode('utf-8')
         response.close()
-        if source_type == "js":
-            o.write('<script type="text/javascript">\n')
-        else:
-            o.write('<style type="text/css">\n')
         o.write(content)
         if source_type == "js":
             o.write('</script>\n')
         else:
             o.write('</style>\n')
-
-
+    else:
+        raise ValueError("No file path in {l} for inline script.".format(l=line))
 
 
 def main():

--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -14,7 +14,7 @@ def create_report(args):
     variants_file = args.sites
 
     if variants_file.endswith(".vcf") or variants_file.endswith (".vcf.gz"):
-        table = VariantTable(variants_file, args.info_columns, args.sample_columns)
+        table = VariantTable(variants_file, args.species, args.info_columns, args.sample_columns)
 
     elif variants_file.endswith(".bed") or variants_file.endswith(".bed.gz"):
         table = BedTable(variants_file)
@@ -160,6 +160,7 @@ def main():
     parser.add_argument("--output", help="output file name", default="igvjs_viewer.html")
     parser.add_argument("--info-columns", nargs="+", help="list of VCF info field names to include in variant table")
     parser.add_argument("--sample-columns", nargs="+", help="list of VCF sample/format field names to include in variant table")
+    parser.add_argument("--species", help="Latin species name with underscore as used by ensembl.org", default='homo_sapiens')
     parser.add_argument("--flanking", help="genomic region to include either side of variant", default=1000)
     parser.add_argument('--standalone', help='Print more data', action='store_true')
     args = parser.parse_args()

--- a/igv_reports/varianttable.py
+++ b/igv_reports/varianttable.py
@@ -45,7 +45,7 @@ class VariantTable:
                 v = ''
                 if h in variant.info:
                     if h == 'ANN':
-                        genes, effects, impacts, transcript, aa_alt, nt_alt = decode_ann(variant)
+                        genes, effects, impacts, transcript, gene_id, aa_alt, nt_alt = decode_ann(variant)
                     elif h == 'COSMIC_ID':
                         v = render_id(v)
                     else:
@@ -55,6 +55,7 @@ class VariantTable:
                     obj['EFFECTS'] = effects
                     obj['IMPACT'] = impacts
                     obj['TRANSCRIPT'] = transcript
+                    obj['GENE_ID'] = gene_id
                     obj['PROTEIN ALTERATION'] = aa_alt
                     obj['DNA ALTERATION'] = nt_alt
                 else:
@@ -120,11 +121,12 @@ def decode_ann(variant):
     effects = []
     impacts = []
     transcripts = []
+    gene_ids = []
     aa_alts = []
     nt_alts = []
     for allele in variant.alts:
         for ann in annotations:
-            ann_allele, kind, impact, gene = ann[:4]
+            ann_allele, kind, impact, gene, gene_id = ann[:5]
             feature_id = ann[6]
             nt_mod, aa_mod = ann[9:11]
 
@@ -135,9 +137,10 @@ def decode_ann(variant):
             # Keep the most severe effect.
             # Link out to Genecards and show the full record in a tooltip.
             genes.append(gene)
+            gene_ids.append(gene_id)
             effects.append(kind.replace('&', '/'))
             impacts.append(impact)
             transcripts.append(feature_id)
             aa_alts.append(aa_mod)
             nt_alts.append(nt_mod)
-    return ','.join(genes), ','.join(effects), ','.join(impacts), ','.join(transcripts), ','.join(aa_alts), ','.join(nt_alts)
+    return ','.join(genes), ','.join(effects), ','.join(impacts), ','.join(transcripts), ','.join(gene_ids), ','.join(aa_alts), ','.join(nt_alts)

--- a/igv_reports/varianttable.py
+++ b/igv_reports/varianttable.py
@@ -44,7 +44,7 @@ class VariantTable:
                 v = ''
                 if h in variant.info:
                     if h == 'ANN':
-                        genes, effects, impacts, feature = decode_ann(variant)
+                        genes, effects, impacts, transcript, aa_alt, nt_alt = decode_ann(variant)
                     elif h == 'COSMIC_ID':
                         v = render_id(v)
                     else:
@@ -53,7 +53,9 @@ class VariantTable:
                     obj['GENE'] = genes
                     obj['EFFECTS'] = effects
                     obj['IMPACT'] = impacts
-                    obj['FEATURE'] = feature
+                    obj['TRANSCRIPT'] = transcript
+                    obj['PROTEIN ALTERATION'] = aa_alt
+                    obj['DNA ALTERATION'] = nt_alt
                 else:
                     obj[h] = v
 
@@ -110,19 +112,14 @@ def decode_ann(variant):
     genes = []
     effects = []
     impacts = []
-    feature = []
+    transcripts = []
+    aa_alts = []
+    nt_alts = []
     for allele in variant.alts:
         for ann in annotations:
             ann_allele, kind, impact, gene = ann[:4]
             feature_id = ann[6]
             nt_mod, aa_mod = ann[9:11]
-            if aa_mod:
-                # add separator if present
-                aa_mod = f':{aa_mod}'
-            if nt_mod:
-                # add separator if present
-                nt_mod = f':{nt_mod}'
-
 
             if allele != ann_allele:
                 continue
@@ -134,11 +131,8 @@ def decode_ann(variant):
                            f'gene={gene}" target="_blank">{gene}</a>')
             effects.append(kind.replace('&', ', '))
             impacts.append(impact)
-            feature.append(f'{feature_id}{aa_mod}{nt_mod}')
-            """
-            effects.append(f'<a href="https://www.genecards.org/cgi-bin/carddisp.pl?'
-                           f'gene={gene}" target="_blank">{gene}</a>:<abbr title="{full}">'
-                           f'{kind}:{impact}:{feature_id}{aa_mod}{nt_mod}</abbr>')
-            """
+            transcripts.append(f'<a href="https://www.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t={feature_id}" target="_blank">{feature_id}</a>')
+            aa_alts.append(f'<a href="https://www.google.com/search?q={gene}&as_epq={aa_mod}" target="_blank">{aa_mod}</a>')
+            nt_alts.append(f'<a href="https://www.google.com/search?q={gene}&as_epq={nt_mod}" target="_blank">{nt_mod}</a>')
             break
-    return ','.join(genes), ','.join(effects), ','.join(impacts), ','.join(feature)
+    return ','.join(genes), ','.join(effects), ','.join(impacts), ','.join(transcripts), ','.join(aa_alts), ','.join(nt_alts)

--- a/igv_reports/varianttable.py
+++ b/igv_reports/varianttable.py
@@ -6,7 +6,7 @@ from .feature import Feature
 class VariantTable:
 
     # Always remember the *self* argument
-    def __init__(self, vcfFile, info_columns = None, sample_columns = None):
+    def __init__(self, vcfFile, species, info_columns = None, sample_columns = None):
 
         vcf = pysam.VariantFile(vcfFile)
 
@@ -14,6 +14,7 @@ class VariantTable:
         self.sample_fields = sample_columns or []
         self.variants = []
         self.features = []   #Bed-like features
+        self.species = species
 
         for unique_id, var in enumerate(vcf.fetch()):
             self.variants.append((var, unique_id))
@@ -44,7 +45,7 @@ class VariantTable:
                 v = ''
                 if h in variant.info:
                     if h == 'ANN':
-                        genes, effects, impacts, transcript, aa_alt, nt_alt = decode_ann(variant)
+                        genes, effects, impacts, transcript, aa_alt, nt_alt = decode_ann(variant, self.species)
                     elif h == 'COSMIC_ID':
                         v = render_id(v)
                     else:
@@ -104,7 +105,7 @@ def render_ids(v):
     return ','.join(map(render_id, v.split(';')))
 
 
-def decode_ann(variant):
+def decode_ann(variant, species):
     """Decode the standardized ANN field to something human readable."""
     annotations = ([variant.info['ANN'].split('|'
                    )] if isinstance(variant.info['ANN'],
@@ -127,12 +128,11 @@ def decode_ann(variant):
             full = '|'.join(ann)
             # Keep the most severe effect.
             # Link out to Genecards and show the full record in a tooltip.
-            genes.append(f'<a href="https://www.genecards.org/cgi-bin/carddisp.pl?'
-                           f'gene={gene}" target="_blank">{gene}</a>')
-            effects.append(kind.replace('&', ', '))
+            genes.append(f'<a href="https://www.ensembl.org/{species}/Gene/'
+                           f'Summary?db=core;t={gene}" target="_blank">{gene}</a>')
+            effects.append(kind.replace('&', '/'))
             impacts.append(impact)
-            transcripts.append(f'<a href="https://www.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t={feature_id}" target="_blank">{feature_id}</a>')
+            transcripts.append(f'<a href="https://www.ensembl.org/{species}/Transcript/Summary?db=core;t={feature_id}" target="_blank">{feature_id}</a>')
             aa_alts.append(f'<a href="https://www.google.com/search?q={gene}&as_epq={aa_mod}" target="_blank">{aa_mod}</a>')
             nt_alts.append(f'<a href="https://www.google.com/search?q={gene}&as_epq={nt_mod}" target="_blank">{nt_mod}</a>')
-            break
     return ','.join(genes), ','.join(effects), ','.join(impacts), ','.join(transcripts), ','.join(aa_alts), ','.join(nt_alts)


### PR DESCRIPTION
This PR contains two changes.

- Added parsing of linked css files in addition to javascript files when applying the standalone parameter. There for the inline_script function has been modified.
- Removal of previously introduced google and ensembl linkouts [(PR)](https://github.com/igvteam/igv-reports/pull/34). It showed that it is more convenient to utilize linkouts in the html-template file. Customizing the template has the advantage that we don't need to worry about skipping licenses or regional limitations of search engines.