### PR TITLE
enforce min bound on flanked region; skip empty gff3 lines

### DIFF
--- a/igv_reports/feature.py
+++ b/igv_reports/feature.py
@@ -172,6 +172,9 @@ def parse_gff(f):
     for line in f:
         if not (line.startswith('#') or line.startswith('track') or line.startswith('browser')):
             tokens = line.rstrip('\n').rstrip('\r').split('\t')
+            # if we encounter a blank or malformed line (no start and end coords), skip it
+            if len(tokens)<5:
+                continue
             chr = tokens[0]
             start = int(tokens[3]) - 1
             end = int(tokens[4])

--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -76,6 +76,7 @@ def create_report(args):
             else:
                 chr = feature.chr
                 start = int (math.floor(feature.start - flanking / 2))
+                start = max(start,1) # bound start to 1
                 end = int (math.ceil(feature.end + flanking / 2))
                 region = {
                     "chr": chr,


### PR DESCRIPTION
* Some gff3 files from genbank can have blank lines at the end. This adds a check that each line in a gff file has enough tokens to have start and end coords, and skips the line if not.
* On short genomes such as viral, the start coord can go negative for variants near position 1 with sizable flank sizes (or not so sizable, depending). This enforces a min start coord of 1. The end coord fix is TBD