### PR TITLE
Add --title to variant html template

### DIFF
--- a/igv_reports/templates/variant_template-2.html
+++ b/igv_reports/templates/variant_template-2.html
@@ -140,6 +140,7 @@
 
 <body>
 
+<!--title-->
 
 <div id="tableContainer" class="wrap-collabsible">
     <input id="collapsible" class="toggle" type="checkbox" checked>


### PR DESCRIPTION
Currently, `--title` only works with the junction html template. See [here](https://github.com/igvteam/igv-reports/blob/v1.7.0/igv_reports/templates/junction_template.html#L124)

The Variant html template lost its `<!--title-->` comment that allowed the user to define it. See previous [commit](https://github.com/igvteam/igv-reports/commit/e1cde48cd9e954e4f47d96e4f73e78fbe1d82a66) from @jrobinso.

