### PR TITLE
fix bug in tsv header being retained as data row

### DIFF
--- a/igv_reports/generictable.py
+++ b/igv_reports/generictable.py
@@ -28,21 +28,20 @@ class GenericTable:
             sys.exit(msg)
 
         regions = []
-        header = None
         rows = parse(file, 'tab')
-        header = None
         unique_id = 0
         start_offset = 0 if zero_based else 1
+
+        # set header to be first row and assume file has a header
+        header = rows[0]
+        rows.pop(0)
+        
         for row in rows:
-            # first line is the header
-            if header is None:
-                header = row
-            else:
-                chr = row[seq_col]
-                start = int(row[start_col]) - start_offset
-                end = int(row[end_col])
-                regions.append((_Region(chr, start, end), unique_id))
-                unique_id += 1
+            chr = row[seq_col]
+            start = int(row[start_col]) - start_offset
+            end = int(row[end_col])
+            regions.append((_Region(chr, start, end), unique_id))
+            unique_id += 1
 
         return GenericTable(rows, regions, info_columns, header)
 


### PR DESCRIPTION
Appears to be a bug in handled tab files whereby the header is always treat as the first line of data, using a minimal test file produces the following:
```
chrom   start   end     field1  field2  field3
1       1252534 1252566 a       b       c
2       2337465 2337499 d       e       f
```
![image](https://github.com/igvteam/igv-reports/assets/45037268/577cc22b-7351-4ce3-9c34-e74281fefd40)

This looks to come from the fact the rows are parsed from the file, the first line is treat as the header but then not removed from the list of rows. With the changes this fixes it and produces a file with expected header:
![image](https://github.com/igvteam/igv-reports/assets/45037268/54964ef5-1900-4e0d-ae2d-d99354197702)
