### PR TITLE
translate-sequence-track option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ are described below. Although _--tracks_ is optional, a typical report will incl
       for more details
     * __--maxlen__ INT. Maximum length of a variant (SV) to show in a single view. Variants exceeding this length will
       be shown in a split-screen (multilocus) view. default = 10000
+    * __--translate-sequence-track__ Three-frame Translate sequence track
 
 **Track file formats:**
 

--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -266,6 +266,8 @@ def create_session_dict(args, table, trackjson):
 
             # Loop through track configs
             tracks = []
+            if args.translate_sequence_track:
+                tracks.append({ "type":"sequence", "frameTranslate": True })
             roi = []
             track_order = 1
             idx = 0
@@ -500,6 +502,7 @@ def main():
     parser.add_argument("--no-embed", help="Do not embed fasta or track data.  This is not common", action="store_true")
     parser.add_argument("--subsample", type=float,  help="Subsample bam files, keeping fraction of input alignments as indicated by input value in the range of 0.0 - 1.0")
     parser.add_argument("--maxlen", type=int, default=10000, help="Maximum length of variant for single  view. Variants exceeding this lenght will be presented in split-screen (multilocus) view")
+    parser.add_argument("--translate-sequence-track", help="Three-frame Translate sequence track", action="store_true")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
The new option `translate-sequence-track` for the create_report function is switching the first sequence track in codon view mode (Three-frame Translate).