### PR TITLE
Add utility to change default zoom

### DIFF
--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -104,7 +104,7 @@ def create_report(args):
 
     if args.no_embed == True:
         igv_config = json.dumps(create_noembed_session(args, trackjson))
-        locus_dict = json.dumps(create_locus_dict(table, args.zoom))
+        locus_dict = json.dumps(create_locus_dict(table, args.window))
 
     # Create the session dictionary json, containing a session object for each variant
     else:
@@ -259,9 +259,9 @@ def create_session_dict(args, table, trackjson):
             if (hasattr(feature, "viewport")):
                 initial_locus = feature.viewport
             else:
-                initial_locus = locus_string(feature.chr, feature.start, feature.end, args.zoom)
+                initial_locus = locus_string(feature.chr, feature.start, feature.end, args.window)
                 if region2 is not None:
-                    initial_locus += f' {locus_string(feature.chr2, feature.start2, feature.end2, args.zoom)}'
+                    initial_locus += f' {locus_string(feature.chr2, feature.start2, feature.end2, args.window)}'
 
 
             # Loop through track configs
@@ -360,7 +360,7 @@ def create_noembed_session(args, trackjson):
     return session
 
 
-def create_locus_dict(table, zoom):
+def create_locus_dict(table, window):
     locus_dict = {}
 
     # loop through regions defined from variant, annotation, or bedpe files,  creating  locus for each one
@@ -378,9 +378,9 @@ def create_locus_dict(table, zoom):
         if (hasattr(feature, "viewport")):
             locus = feature.viewport
         else:
-            locus = locus_string(feature.chr, feature.start + 1, feature.end, zoom)
+            locus = locus_string(feature.chr, feature.start + 1, feature.end, window)
             if hasattr(feature, 'chr2') and feature.chr2 is not None:
-                locus += f' {locus_string(feature.chr2, feature.start2, feature.end2, zoom)}'
+                locus += f' {locus_string(feature.chr2, feature.start2, feature.end2, window)}'
 
         locus_dict[session_id] = locus
 
@@ -414,12 +414,18 @@ def inline_script(line, o, source_type):
         raise ValueError("No file path in {l} for inline script.".format(l=line))
 
 
-def locus_string(chr, start, end, zoom):
+def locus_string(chr, start, end, window):
     if start is None:
         return chr
 
-    zoom = int(zoom)
-    return f'{chr}:{start + 1 - zoom/2}-{end+zoom/2}'
+    if window is not None:
+		window = int(window)
+        return f'{chr}:{start + 1 - window/2}-{end+window/2}'
+    else:
+        if (end - start) == 1:
+            return f'{chr}:{start + 1}'
+        else:
+            return f'{chr}:{start + 1}-{end}'
 
 
 # Potentially add an index URL to a track config.  The "format" field must be set before calling this function
@@ -485,7 +491,7 @@ def main():
     parser.add_argument("--sample-columns", nargs="+",
                         help="list of VCF sample (genomtype) FORMAT field names to include in variant table")
     parser.add_argument("--flanking", help="genomic region to include either side of variant", default=1000)
-    parser.add_argument("--zoom", help="initial zoom level of genomic region", default=40)
+    parser.add_argument("--window", help="initial window zoom level of genomic region", default=None)
     parser.add_argument("--standalone", help="embed javascript as well as data in output html", action='store_true')
     parser.add_argument("--title", help="optional title string")
     parser.add_argument("--sequence", help="Column of sequence (chromosome) name.  For tab-delimited sites file.",

--- a/igv_reports/report.py
+++ b/igv_reports/report.py
@@ -491,7 +491,7 @@ def main():
     parser.add_argument("--sample-columns", nargs="+",
                         help="list of VCF sample (genomtype) FORMAT field names to include in variant table")
     parser.add_argument("--flanking", help="genomic region to include either side of variant", default=1000)
-    parser.add_argument("--window", help="initial window zoom level of genomic region", default=None)
+    parser.add_argument("--window", help="initial visible window size (genomic region) in bp.  If not supplied igv.js default applies (40 bp).", default=None)
     parser.add_argument("--standalone", help="embed javascript as well as data in output html", action='store_true')
     parser.add_argument("--title", help="optional title string")
     parser.add_argument("--sequence", help="Column of sequence (chromosome) name.  For tab-delimited sites file.",


### PR DESCRIPTION
Currently the zoom is set to the default of 40 (I believe this stems from the minimum bases being 39 but I have not verified) such that using only a single position (chr5	474989) results in a 41bp window (chr5:474,969-475,009). I added an argument that allows users to change this value. The default is set to 40, so the current output is maintained in the absence of this argument. 

Let me know if you have any comments.

