### PR TITLE
Respect --exclude-flags 0

### DIFF
--- a/igv_reports/tracks.py
+++ b/igv_reports/tracks.py
@@ -19,6 +19,10 @@ def get_track_json_dict(url):
         trackobj["height"] = 50
         trackobj["color"] = "rgb(0,0,150)"
 
+    # To respect --exclude-flags, show all reads which are already filtered by
+    # pysam in bam.py. igv.js defaults duplicate and vendorFailed to True.
+    if format == "bam" or format == "cram":
+        trackobj["filter"] = {"duplicate": False, "vendorFailed": False}
     return trackobj
 
 def get_name(filename):
@@ -61,6 +65,3 @@ def get_track_type(format):
 
 def is_format_supported(format):
     return get_track_type(format) is not None
-
-
-


### PR DESCRIPTION
Update tracks.py to set duplicate and vendorFailed in Bam track's options to True. Otherwise, igv.js will filter out duplicate and vendorFailed reads even though `--exclude-flags` is 0.

Since pysam filters out reads before serializing the data into data url, this PR fixes this bug by making igv.js to show all reads.